### PR TITLE
use trusted code inspector

### DIFF
--- a/iracket.rkt
+++ b/iracket.rkt
@@ -61,7 +61,7 @@
                  [sandbox-security-guard      (current-security-guard)] 
                  ;; [sandbox-exit-handler        _] ;; trusted = (exit-handler)
                  ;; [sandbox-make-inspector      _] ;; trusted = current-inspector
-                 ;; [sandbox-make-code-inspector _] ;; trusted = current-code-inspector
+                 [sandbox-make-code-inspector current-code-inspector] ;; trusted = current-code-inspector
                  ;; [sandbox-make-plumber 'propagate] ;; trusted = current-plumber
                  ;; [sandbox-make-environment-variables *copy*] ;; trusted = current-environment-variables
                  ;; -- Same as trusted:


### PR DESCRIPTION
Without this, if a package is installed AFTER the kernel has started, requiring the package will fail:

1. Step 1: start a iracket kernel

2. Step 2: install rebellion

```sh
raco pkg install --no-docs rebellion
```

3. Step 3: in the **existing** kernel, run:

```rkt
(require rebellion)
;; > eval-linklet: cannot use unsafe linklet loaded with non-original code inspector
```

Ref: https://racket.discourse.group/t/how-to-create-the-most-permissive-security-guard-for-a-racket-sandbox/2071/5